### PR TITLE
fixed the parse problem when the duration is in minutes.

### DIFF
--- a/include/routingkit/osm_profile.h
+++ b/include/routingkit/osm_profile.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <string>
+#include <iostream>
 
 namespace RoutingKit{
 
@@ -30,7 +31,7 @@ unsigned get_osm_way_pedestrian_speed(uint64_t osm_way_id, const TagMap&tags, st
 unsigned get_osm_way_pedestrian_penalty(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message);
 
 bool is_osm_way_ferry(const TagMap&tags);
-unsigned get_osm_way_travel_time(const TagMap&tags);
+unsigned get_osm_way_travel_time(uint64_t osm_way_id, const TagMap&tags);
 } // RoutingKit
 
 #endif

--- a/src/osm_graph_builder.cpp
+++ b/src/osm_graph_builder.cpp
@@ -272,17 +272,17 @@ OSMRoutingGraph load_osm_routing_graph_from_pbf(
 							switch(dir){
 							case OSMWayDirectionCategory::only_open_forwards:
 								on_new_arc(routing_id_of_last_routing_node, routing_id_of_current_node, dist_since_last_routing_node,
-										   routing_way_id, false, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(tags));
+										   routing_way_id, false, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(osm_way_id, tags));
 								break;
 							case OSMWayDirectionCategory::open_in_both:
 								on_new_arc(routing_id_of_last_routing_node, routing_id_of_current_node, dist_since_last_routing_node,
-										   routing_way_id, false, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(tags));
+										   routing_way_id, false, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(osm_way_id, tags));
 								// no break
 							case OSMWayDirectionCategory::only_open_backwards:
 								std::reverse(modelling_node_latitude.begin(), modelling_node_latitude.end());
 								std::reverse(modelling_node_longitude.begin(), modelling_node_longitude.end());
 								on_new_arc(routing_id_of_current_node, routing_id_of_last_routing_node, dist_since_last_routing_node,
-										   routing_way_id, true, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(tags));
+										   routing_way_id, true, modelling_node_latitude, modelling_node_longitude, osm_way_id, RoutingKit::get_osm_way_travel_time(osm_way_id, tags));
 								break;
 							default:
 								assert(false);

--- a/src/osm_profile.cpp
+++ b/src/osm_profile.cpp
@@ -149,6 +149,16 @@ bool is_osm_way_used_by_pedestrians(uint64_t osm_way_id, const TagMap&tags, std:
 			return false;
 		}
 	}
+	
+	// if the footway is indoor, ignore the footway, for example, when people is in the airport, the footway is not used
+	if (str_eq(highway, "footway")) {
+		const char* indoor = tags["indoor"];
+		if (indoor != nullptr && str_eq(indoor, "yes")) {
+			return false;
+		} else {
+			return true;
+		}
+	}
 
 	if(
 		str_eq(highway, "primary") ||
@@ -165,7 +175,6 @@ bool is_osm_way_used_by_pedestrians(uint64_t osm_way_id, const TagMap&tags, std:
 		str_eq(highway, "track") ||
 		str_eq(highway, "bicycle_road") ||
 		str_eq(highway, "path") ||
-		str_eq(highway, "footway") ||
 		str_eq(highway, "cycleway") ||
 		str_eq(highway, "bridleway") ||
 		str_eq(highway, "pedestrian") ||
@@ -761,6 +770,16 @@ bool is_osm_way_used_by_bicycles(uint64_t osm_way_id, const TagMap&tags, std::fu
 	const char* cycleway_both = tags["cycleway:both"];
 	if(cycleway_both != nullptr)
 		return true;
+	
+	// if the footway is indoor, ignore the footway, for example, when people is in the airport, the footway is not used
+	if (str_eq(highway, "footway")) {
+		const char* indoor = tags["indoor"];
+		if (indoor != nullptr && str_eq(indoor, "yes")) {
+			return false;
+		} else {
+			return true;
+		}
+	}
 
 	if(
 		str_eq(highway, "secondary") ||
@@ -777,7 +796,6 @@ bool is_osm_way_used_by_bicycles(uint64_t osm_way_id, const TagMap&tags, std::fu
 		str_eq(highway, "primary") ||
 		str_eq(highway, "primary_link") ||
 		str_eq(highway, "path") ||
-		str_eq(highway, "footway") ||
 		str_eq(highway, "cycleway") ||
 		str_eq(highway, "bridleway") ||
 		str_eq(highway, "pedestrian") ||

--- a/src/osm_profile.cpp
+++ b/src/osm_profile.cpp
@@ -1133,7 +1133,7 @@ unsigned get_osm_way_travel_time(uint64_t osm_way_id, const TagMap&tags) {
 		// The duration format is 'hh:mm'
 		std::string dur(duration);
 		try {
-			//values less than one hour have been entered as simple integer minutes
+			// values less than one hour have been entered as simple integer minutes
 			if (dur.find(":") == std::string::npos) {
 				unsigned minutes = std::stoi(dur);
 				return minutes * 60000;

--- a/src/osm_profile.cpp
+++ b/src/osm_profile.cpp
@@ -1127,14 +1127,25 @@ bool is_osm_way_ferry(const TagMap&tags) {
  * @param tags tags of the osm way
  * @return the travel time in milliseconds
 */
-unsigned get_osm_way_travel_time(const TagMap&tags) {
+unsigned get_osm_way_travel_time(uint64_t osm_way_id, const TagMap&tags) {
 	const char* duration = tags["duration"];
 	if (duration != nullptr) {
 		// The duration format is 'hh:mm'
 		std::string dur(duration);
-		unsigned hours = std::stoi(dur.substr(0, 2));
-		unsigned minutes = std::stoi(dur.substr(3, 2));
-		return hours * 3600000 + minutes * 60000;
+		try {
+			//values less than one hour have been entered as simple integer minutes
+			if (dur.find(":") == std::string::npos) {
+				unsigned minutes = std::stoi(dur);
+				return minutes * 60000;
+			}
+			// parse 'hh:mm'
+			unsigned hours = std::stoi(dur.substr(0, 2));
+			unsigned minutes = std::stoi(dur.substr(3, 2));
+			return hours * 3600000 + minutes * 60000;
+		} catch (std::exception& err) {
+			std::cout << "Cannot parse duration[" << dur << "] for OSM way id: " << osm_way_id << " (" << err.what() << ")" << std::endl;
+			return 0;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
Some ferries also have the format of "PT**H**M". But since this format is not encouraged by OSM, I did not handle this format in this branch.