### PR TITLE
override direction information

### DIFF
--- a/src/osm_profile.cpp
+++ b/src/osm_profile.cpp
@@ -443,6 +443,9 @@ bool is_osm_way_used_by_cars(uint64_t osm_way_id, const TagMap&tags, std::unorde
 
 
 OSMWayDirectionCategory get_osm_car_direction_category(uint64_t osm_way_id, const TagMap&tags, std::function<void(const std::string&)>log_message){
+	if (osm_way_id == 875901608) {
+		return OSMWayDirectionCategory::only_open_forwards;
+	}
 	const char
 		*oneway = tags["oneway"],
 		*junction = tags["junction"],


### PR DESCRIPTION
[Ticket](https://takemobi.atlassian.net/browse/CPS-599)
TUI has requested us to override the road direction to make it one-way.

TODO: in the future we might need to use a file to record these road direction overrides, just like "road-block.txt"